### PR TITLE
Re-use code in timer.lua (src/lib)

### DIFF
--- a/src/lib/timer.lua
+++ b/src/lib/timer.lua
@@ -21,15 +21,7 @@ end
 function timer.queue( n, response )
 	parameters.check( 2, "n", "number", n, "response", "function", response )
 
-	local finish, ID = t + n, false -- avoids duplicating timer events
-	for i = 1, #timers do
-		if timers[i].time == finish then
-			ID = timers[i].ID
-			break
-		end
-	end
-
-	local timerID = ID or os.startTimer( n )
+	local timerID = timer.new( n )
 	timers[#timers + 1] = { time = finish, response = response, ID = timerID }
 	return timerID
 end


### PR DESCRIPTION
As you can see, `timer.queue` uses the exact same code as `timer.new` so I thought rather than leaving `timer.new` unused, I could integrate it into `queue`.

Perhaps I am missing something obvious, do let me know.
